### PR TITLE
space will cause an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ chkconfig nfslock on
 
 ```bash
 cat > /etc/exports <<'EOF'
-/some/folder client.example.com(ro, sync)
+/some/folder client.example.com(ro,sync)
 EOF
 
 exportfs -a


### PR DESCRIPTION
From Jang's book, page 890:

Be very careful with /etc/ exports; one common cause of problems is an extra
space between expressions.  For example, an extra space after either comma in
(ro,no_root_squash,sync) means the specifi ed directory won’t get exported.
